### PR TITLE
Add propertyWrappers for swift >=5.1

### DIFF
--- a/Hopoate.xcodeproj/project.pbxproj
+++ b/Hopoate.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		48E409E121525B7600B0D5B5 /* ServiceProviderRegistrar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48E409E021525B7600B0D5B5 /* ServiceProviderRegistrar.swift */; };
 		48E409E321525BA400B0D5B5 /* DependencyContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48E409E221525BA400B0D5B5 /* DependencyContainer.swift */; };
 		48E409E521525BF100B0D5B5 /* DependencyContainerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48E409E421525BF100B0D5B5 /* DependencyContainerTests.swift */; };
+		964A410B22DDFD1800A7FC02 /* DependencyWrappers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 964A410A22DDFD1800A7FC02 /* DependencyWrappers.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -35,6 +36,7 @@
 		48E409E021525B7600B0D5B5 /* ServiceProviderRegistrar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServiceProviderRegistrar.swift; sourceTree = "<group>"; };
 		48E409E221525BA400B0D5B5 /* DependencyContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DependencyContainer.swift; sourceTree = "<group>"; };
 		48E409E421525BF100B0D5B5 /* DependencyContainerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DependencyContainerTests.swift; sourceTree = "<group>"; };
+		964A410A22DDFD1800A7FC02 /* DependencyWrappers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DependencyWrappers.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -81,6 +83,7 @@
 				48E409E221525BA400B0D5B5 /* DependencyContainer.swift */,
 				48E409E021525B7600B0D5B5 /* ServiceProviderRegistrar.swift */,
 				48E409DE21525B4000B0D5B5 /* ServiceRegistration.swift */,
+				964A410A22DDFD1800A7FC02 /* DependencyWrappers.swift */,
 				48E409C82152598500B0D5B5 /* Info.plist */,
 			);
 			name = Hopoate;
@@ -209,6 +212,7 @@
 			files = (
 				48E409E121525B7600B0D5B5 /* ServiceProviderRegistrar.swift in Sources */,
 				48E409E321525BA400B0D5B5 /* DependencyContainer.swift in Sources */,
+				964A410B22DDFD1800A7FC02 /* DependencyWrappers.swift in Sources */,
 				48E409DF21525B4000B0D5B5 /* ServiceRegistration.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Sources/Hopoate/DependencyWrappers.swift
+++ b/Sources/Hopoate/DependencyWrappers.swift
@@ -1,0 +1,35 @@
+//
+//  DependencyWrappers.swift
+//  Hopoate
+//
+//  Created by Seb Skuse on 16/07/2019.
+//  Copyright © 2019 Darjeeling Apps. All rights reserved.
+//
+
+import Foundation
+
+#if swift(>=5.1)
+
+/// Wraps a required injected dependency using the default container.
+///
+/// Example: @Dependency var someDependency: SomeDependency
+@propertyWrapper
+public struct Dependency<T> {
+    
+    public init() {}
+    
+    public lazy var wrappedValue: T = resolve(T.self)
+}
+
+/// Wraps an optional injected dependency using the default container.
+///
+/// Example: @OptionalDependency var basketManager: BasketManaging
+@propertyWrapper
+public struct OptionalDependency<T> {
+    
+    public init() {}
+    
+    public lazy var wrappedValue: T? = optionalResolve(T.self)
+}
+
+#endif


### PR DESCRIPTION
Does what it says on the tin - adds `@Dependency` and `@OptionalDependency` annotations using the default container. 

Works with the updated `@propertyWrapper` implementation in Xcode 11.0b3 (11M362v), versions prior to that won't work.