### PR TITLE
Overwrite registrations

### DIFF
--- a/Hopoate tvOS/Info.plist
+++ b/Hopoate tvOS/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>

--- a/Hopoate watchOS/Info.plist
+++ b/Hopoate watchOS/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>

--- a/Hopoate.xcodeproj/project.pbxproj
+++ b/Hopoate.xcodeproj/project.pbxproj
@@ -530,7 +530,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.4.0;
+				MARKETING_VERSION = 1.6.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.darjeeling.Hopoate-iOS";
 				PRODUCT_NAME = Hopoate;
 				SKIP_INSTALL = YES;
@@ -561,7 +561,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.4.0;
+				MARKETING_VERSION = 1.6.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.darjeeling.Hopoate-iOS";
 				PRODUCT_NAME = Hopoate;
 				SKIP_INSTALL = YES;
@@ -624,6 +624,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
+				MARKETING_VERSION = 1.6.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.darjeeling.Hopoate-tvOS";
 				PRODUCT_NAME = Hopoate;
 				SDKROOT = appletvos;
@@ -650,6 +651,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
+				MARKETING_VERSION = 1.6.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.darjeeling.Hopoate-tvOS";
 				PRODUCT_NAME = Hopoate;
 				SDKROOT = appletvos;
@@ -677,6 +679,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
+				MARKETING_VERSION = 1.6.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.darjeeling.Hopoate-watchOS";
 				PRODUCT_NAME = Hopoate;
 				SDKROOT = watchos;
@@ -704,6 +707,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
+				MARKETING_VERSION = 1.6.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.darjeeling.Hopoate-watchOS";
 				PRODUCT_NAME = Hopoate;
 				SDKROOT = watchos;

--- a/Sources/Hopoate/DependencyContainer.swift
+++ b/Sources/Hopoate/DependencyContainer.swift
@@ -39,6 +39,31 @@ public final class DependencyContainer {
         return register(service: service, creator: instance)
     }
     
+    /// Registers a creation closure for a given service type and removes any existing services registered for the service type.
+    ///
+    /// - Parameters:
+    ///   - service: The type of service that the creation closure returns.
+    ///   - cacheService: Determines whether the result of calling the creator should be cached or not. Defaults to `true`.
+    ///   - creator: The closure that will be executed when resolving a service of the given type.
+    /// - Returns: The `ServiceRegistration` created during registration. Can be passed to the `remove` function to remove the registration.
+    @discardableResult
+    public func overwriteExistingRegistrations<Service>(service: Service.Type, cacheService: Bool = true, creator: @escaping () -> Service) -> ServiceRegistration<Service> {
+        let registrar = self.registrar(for: service)
+        registrar.removeAllRegistrations()
+        return register(service: service, cacheService: cacheService, creator: creator)
+    }
+    
+    /// Registers a service for a given service type and removes any existing services registered for the service type.
+    ///
+    /// - Parameters:
+    ///   - instance: The closure used to create the service that will be registered.
+    ///   - service: The type of service that the `instance` closure returns.
+    /// - Returns: The `ServiceRegistration` created during registration. Can be passed to the `remove` function to remove the registration.
+    @discardableResult
+    public func overwriteExistingRegistrations<Service>(withService instance: @autoclosure @escaping () -> Service, for service: Service.Type) -> ServiceRegistration<Service> {
+        return overwriteExistingRegistrations(service: service, creator: instance)
+    }
+    
     /// - Parameter serviceType: The service type that we wish to find a service for.
     /// - Returns: A service instance that satisfies the given service type. Requesting a service for a service type that has not been registered is considered a programming error and will cause a fatal error.
     public func resolve<Service>(_ serviceType: Service.Type) -> Service {

--- a/Sources/Hopoate/ServiceProviderRegistrar.swift
+++ b/Sources/Hopoate/ServiceProviderRegistrar.swift
@@ -40,6 +40,11 @@ final class ServiceProviderRegistrar {
         serviceRegistrations.remove(at: index)
     }
     
+    /// Removes all services registered with the receiver.
+    func removeAllRegistrations() {
+        serviceRegistrations.removeAll()
+    }
+    
     /// - Returns: The most recent service registration added to the receiver.
     func mostRecentServiceEntry() -> AnyObject? {
         return serviceRegistrations.last

--- a/Tests/HopoateTests/DependencyContainerTests.swift
+++ b/Tests/HopoateTests/DependencyContainerTests.swift
@@ -86,6 +86,19 @@ class DependencyContainerTests: XCTestCase {
         }
         XCTAssertTrue(dependencyContainer.canResolve(TestProtocol.self))
     }
+    
+    func testItCanOverwriteExistingServiceRegistrations() {
+        let objectOne = TestClass()
+        dependencyContainer.register(objectOne, for: TestProtocol.self)
+        XCTAssertTrue(dependencyContainer.resolve(TestProtocol.self) === objectOne)
+        
+        let objectTwo = TestClass()
+        let objectTwoRegistration = dependencyContainer.overwriteExistingRegistrations(withService: objectTwo, for: TestProtocol.self)
+        XCTAssertTrue(dependencyContainer.resolve(TestProtocol.self) === objectTwo)
+        
+        dependencyContainer.remove(objectTwoRegistration)
+        XCTAssertNil(dependencyContainer.optionalResolve(TestProtocol.self))
+    }
 }
 
 // MARK: - Caching


### PR DESCRIPTION
Allows existing service registrations to be removed when registering a new service instance without client code having to keep track of service registrations.

![Gregg Happy Face](https://user-images.githubusercontent.com/4540313/96480247-e9320900-1231-11eb-9419-a94f8c500e9f.gif)
