### PR TITLE
Isolated dependencies

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,17 +6,18 @@ import PackageDescription
 let package = Package(
     name: "Hopoate",
     platforms: [
-        .iOS(.v12),
-        .tvOS(.v12),
-        .watchOS(.v5)
+        .iOS(.v13),
+        .tvOS(.v13),
+        .watchOS(.v6),
+        .macOS(.v10_15)
     ],
     products: [
-      .library(name: "Hopoate", type: .dynamic, targets: ["Hopoate"])
+        .library(name: "Hopoate", type: .dynamic, targets: ["Hopoate"]),
     ],
     dependencies: [],
     targets: [
-      .target(name: "Hopoate", dependencies: [], resources: [.copy("Resources/PrivacyInfo.xcprivacy")]),
-      .testTarget(name: "HopoateTests", dependencies: ["Hopoate"])
+        .target(name: "Hopoate", dependencies: [], resources: [.copy("Resources/PrivacyInfo.xcprivacy")]),
+        .testTarget(name: "HopoateTests", dependencies: ["Hopoate"])
     ],
     swiftLanguageVersions: [.v5]
 )

--- a/README.md
+++ b/README.md
@@ -135,6 +135,38 @@ Later, in our test function, we execute some code that uses the `AnalyticsProvid
 
 Once the test has run, the `tearDown` function is executed, which sets our `mockAnalyticsContainer` to `nil`. This in turn removes the `MockAnalyticsProvider` from the dependency container, leaving the container in the same state that it was before the test was run.
 
+### Swift Testing
+
+If you are using Swift Testing with Swift 6.1 or above, you can use the `isolatedDependencies` `Suite` `Trait` to provide a test-scoped `DependencyContainer`. Using this method means that:
+- Your dependencies will not clash with other tests when runnning in parallel
+- You do not need to unregister dependencies (unless you really want to).
+
+To use the `isolatedDependencies` trait, create a test suite as such:
+
+```swift
+import Testing
+import HopoateTestingHelpers
+
+
+@MainActor
+@Suite(.isolatedDependencies)
+class MyViewControllerTests {
+
+    private let myViewController = MyViewController()
+    private let mockAnalyticsContainer = MockContainer<AnalyticsProviding, MockAnalyticsProvider>(MockAnalyticsProvider())
+    
+    func testItSendsAMessageToTheAnalyticsProviderWhenTheButtonIsTapped() {
+        whenTheUserTapsTheButton()
+        XCTAssertEqual(mockAnalyticsContainer.mock.receivedMessage, "button_tapped")
+    }
+    
+    private func whenTheUserTapsTheButton() {
+        myViewController.button.sendActions(for: .primaryActionTriggered)
+    }
+}
+
+```
+
 ### Dependency Caching
 
 By default, when a service is registered with the dependency container, the container caches the service that is given in the creation closure.

--- a/Sources/Hopoate/DependencyContainer.swift
+++ b/Sources/Hopoate/DependencyContainer.swift
@@ -12,7 +12,7 @@ import Foundation
 public final class DependencyContainer {
     private var serviceProviderRegistrars = [ServiceProviderRegistrar]()
     
-    public static let shared = DependencyContainer()
+    @TaskLocal public static var shared = DependencyContainer()
     
     public init() {}
     

--- a/Sources/HopoateTestingHelpers/IsolatedDependenciesTrait.swift
+++ b/Sources/HopoateTestingHelpers/IsolatedDependenciesTrait.swift
@@ -1,0 +1,30 @@
+//
+//  MockDependenciesTrait.swift
+//  Hopoate
+//
+//  Created by Seb Skuse on 05/03/2025.
+//
+
+import Testing
+import Hopoate
+
+#if compiler(>=6.1)
+
+/// A trait which provides a new, isolated `DependencyContainer` for each test.
+public struct IsolatedDependenciesTrait: SuiteTrait, TestScoping {
+    public func provideScope(for test: Test, testCase: Test.Case?, performing function: @Sendable () async throws -> Void) async throws {
+        try await DependencyContainer.$shared.withValue(DependencyContainer()) {
+            try await function()
+        }
+    }
+}
+
+public extension Trait where Self == IsolatedDependenciesTrait {
+    
+    /// A trait which provides a new, isolated `DependencyContainer` for each test.
+    static var isolatedDependencies: Self {
+        Self()
+    }
+}
+
+#endif


### PR DESCRIPTION
Adds the ability for us to use isolated dependencies in Swift Testing (see test scoping traits here - https://developer.apple.com/documentation/xcode-release-notes/xcode-16_3-release-notes#Testing-and-Automation).

Separate PR coming up for the testing helpers packages.